### PR TITLE
Update request to support API change. scheduleIntervalInSeconds moved…

### DIFF
--- a/external-synthetic/externalSyntheticExample.py
+++ b/external-synthetic/externalSyntheticExample.py
@@ -29,6 +29,7 @@ payload = {
     }],
     "tests" : [ {
         "id": "1",
+        "scheduleIntervalInSeconds": 60,
         "title": "Example.com",
         "testSetup":  "Python script",
         "drilldownLink": "http://example.com/",
@@ -44,7 +45,6 @@ payload = {
     }],    
     "testResults": [{
         "id": "1",
-        "scheduleIntervalInSeconds": 60,
         "totalStepCount": 1,
         "locationResults": [{
             "id": "1",


### PR DESCRIPTION
… from testResults to tests.

Resolve Github issue **'The property 'scheduleIntervalInSeconds' must not be null or empty'**

There was an external-synthetic API change in 1.150