### PR TITLE
Added json module to save the config in save.py

### DIFF
--- a/configuration/save.py
+++ b/configuration/save.py
@@ -1,7 +1,7 @@
 """
 Example script for fetching given Dynatrace config list items and store them on disk. 
 """
-import requests, ssl, os, sys
+import requests, ssl, os, sys, json
 
 ENV = 'https://<YOUR_ENVIRONMENT.live.dynatrace.com'
 TOKEN = '<YOUR_API_TOKEN>'
@@ -12,7 +12,7 @@ def save(path, file, content):
 	if not os.path.isdir(PATH + path): 
 		os.makedirs(PATH + path)
 	with open(PATH + path + "/" + file, "w", encoding='utf8') as text_file:
-		text_file.write("%s" % content)
+		text_file.write("%s" % json.dumps(content))
 
 def saveList(list_type):
 	try:


### PR DESCRIPTION
Line 15 writes out the config to a file in its "Pythony" form, but unfortunately this is using single quotes for strings and Python style True and False (rather than lowercase true and false) which the Dynatrace API won't accept in the put requests.
Popped in json.dumps() to convert the response data to a json string first.