### PR TITLE
[Synthetics Third-Party Canary-Script] Change metric to loadEventStart

### DIFF
--- a/third-party-synthetic/aws-cloudwatch/dynatrace-canary-exporter.js
+++ b/third-party-synthetic/aws-cloudwatch/dynatrace-canary-exporter.js
@@ -95,7 +95,7 @@
                         log.error('DT: A response was unexpectedly missing for the URL: ' + page.url());
                     }
                 } else {
-                    const metric = await page.evaluate(() => performance.getEntriesByType('navigation')[0].duration);
+                    const metric = await page.evaluate(() => performance.getEntriesByType('navigation')[0].loadEventStart);
                     const startTime = await page.evaluate(() => performance.timeOrigin);
                     const status = response.status;
                     const success = isSuccessfulStatusCode(status);


### PR DESCRIPTION
Use `loadEventStart` instead of `duration`.

Using `duration` in the load event can probably lead to a race condition, because it's calculated using the `loadEventEnd` metric which obviously isn't set at the beginning of the load event.

`duration` often does work. Probably, because the browser events and puppeteer events aren't kept perfectly in sync due to asynchronous actions.