### PR TITLE
[Synthetics Third-Party Canary-Script]: add and automate tests

### DIFF
--- a/.github/workflows/test-dynatrace-canary-exporter.yml
+++ b/.github/workflows/test-dynatrace-canary-exporter.yml
@@ -1,0 +1,29 @@
+name: Test Dynatrace Canary Exporter
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths: 
+      - 'third-party-synthetic/aws-cloudwatch/**'
+
+jobs:
+  test:
+    name: Test on node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./third-party-synthetic/aws-cloudwatch/tests
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm test

--- a/third-party-synthetic/aws-cloudwatch/dynatrace-canary-exporter.js
+++ b/third-party-synthetic/aws-cloudwatch/dynatrace-canary-exporter.js
@@ -1,12 +1,12 @@
 /**
  * Dynatrace AWS CloudWatch Synthetics Canary exporter
- * v1.0.1
+ * v1.0.2
  */
 
 (function () {
+    // -- Imports --
+    const log = require('SyntheticsLogger');
     try {
-        // -- Imports --
-        const log = require('SyntheticsLogger');
         const synthetics = require('Synthetics');
         const https = require('https');
         const http = require('http');


### PR DESCRIPTION
Add a GitHub action that is triggered for pull requests that include changes in the third-party-synthetic/aws-cloudwatch directory.
Add tests that should be triggered by the GitHub action.