### PR TITLE
Third party monitor canary updates

### DIFF
--- a/third-party-synthetic/aws-cloudwatch/dynatrace-canary-exporter.js
+++ b/third-party-synthetic/aws-cloudwatch/dynatrace-canary-exporter.js
@@ -1,6 +1,6 @@
 /**
  * Dynatrace AWS CloudWatch Synthetics Canary exporter
- * v1.0.3
+ * v1.0.4
  */
 
 (function () {
@@ -104,28 +104,27 @@
                         log.error('DT: A response was unexpectedly missing for the URL: ' + page.url());
                     }
                 } else {
-		    onStepResult(new Promise(async (resolve) => {  
-			    const metric = await page.evaluate(() => performance.getEntriesByType('navigation')[0].loadEventStart);
-			    const startTime = await page.evaluate(() => performance.timeOrigin);
-			    const status = response.status;
-			    const success = isSuccessfulStatusCode(status);
-			    const title = (await page.title()) || page.url();
+                    onStepResult(new Promise(async (resolve) => {
+                        const metric = await page.evaluate(() => performance.getEntriesByType('navigation')[0].loadEventStart);
+                        const startTime = await page.evaluate(() => performance.timeOrigin);
+                        const status = response.status;
+                        const success = isSuccessfulStatusCode(status);
+                        const title = (await page.title()) || page.url();
 
-			    const stepResult = {
-				title: title,
-				startTimestamp: startTime,
-				responseTimeMillis: metric,
-				errorWrapper: success ? {} : {
-				    error: {
-					message: `Failed to load: '${title}' (${page.url()}).`,
-					code: status,
-				    }
-				}
-			    };
-
-			    log.info(`DT: Step result (web page): ${JSON.stringify(stepResult)}.`);
-			    resolve(stepResult);
-		    }));
+                        const stepResult = {
+                            title: title,
+                            startTimestamp: startTime,
+                            responseTimeMillis: metric,
+                            errorWrapper: success ? {} : {
+                                error: {
+                                    message: `Failed to load: '${title}' (${page.url()}).`,
+                                    code: status,
+                                }
+                            }
+                        };
+                        log.info(`DT: Step result (web page): ${JSON.stringify(stepResult)}.`);
+                        resolve(stepResult);
+                    }));
                 }
             });
         }
@@ -134,7 +133,7 @@
         // ----- Web api Canary step builder: START -----
         const ignoredApiUrlPatterns = [
             /^monitoring\..*\.amazonaws.com(\/.*)?$/, // Where synthetics posts canary results
-	    /^cw-syn-results(.*)\.amazonaws\.com(.*)?$/, // where synthetics posts canary screenshots
+            /^cw-syn-results(.*)\.amazonaws\.com(.*)?$/, // where synthetics posts canary screenshots
             /^s3\.amazonaws\.com\/$/, // 
         ];
 

--- a/third-party-synthetic/aws-cloudwatch/dynatrace-canary-exporter.js
+++ b/third-party-synthetic/aws-cloudwatch/dynatrace-canary-exporter.js
@@ -103,26 +103,28 @@
                         log.error('DT: A response was unexpectedly missing for the URL: ' + page.url());
                     }
                 } else {
-                    const metric = await page.evaluate(() => performance.getEntriesByType('navigation')[0].loadEventStart);
-                    const startTime = await page.evaluate(() => performance.timeOrigin);
-                    const status = response.status;
-                    const success = isSuccessfulStatusCode(status);
-                    const title = (await page.title()) || page.url();
+		    onStepResult(new Promise(async (resolve) => {  
+			    const metric = await page.evaluate(() => performance.getEntriesByType('navigation')[0].loadEventStart);
+			    const startTime = await page.evaluate(() => performance.timeOrigin);
+			    const status = response.status;
+			    const success = isSuccessfulStatusCode(status);
+			    const title = (await page.title()) || page.url();
 
-                    const stepResult = {
-                        title: title,
-                        startTimestamp: startTime,
-                        responseTimeMillis: metric,
-                        errorWrapper: success ? {} : {
-                            error: {
-                                message: `Failed to load: '${title}' (${page.url()}).`,
-                                code: status,
-                            }
-                        }
-                    };
+			    const stepResult = {
+				title: title,
+				startTimestamp: startTime,
+				responseTimeMillis: metric,
+				errorWrapper: success ? {} : {
+				    error: {
+					message: `Failed to load: '${title}' (${page.url()}).`,
+					code: status,
+				    }
+				}
+			    };
 
-                    onStepResult(stepResult);
-                    log.info(`DT: Step result (web page): ${JSON.stringify(stepResult)}.`);
+			    log.info(`DT: Step result (web page): ${JSON.stringify(stepResult)}.`);
+			    resolve(stepResult);
+		    }));
                 }
             });
         }

--- a/third-party-synthetic/aws-cloudwatch/dynatrace-canary-exporter.js
+++ b/third-party-synthetic/aws-cloudwatch/dynatrace-canary-exporter.js
@@ -51,6 +51,7 @@
             _stepResults$.length = originalFuncs.length = 0;
 
             // ----- Web page Canary instrumentation: START -----
+
             saveFunc(synthetics, 'getPage');
             // The original synthetics.getPage function that we override
             const originalGetPage = synthetics.getPage;
@@ -133,6 +134,8 @@
         // ----- Web api Canary step builder: START -----
         const ignoredApiUrlPatterns = [
             /^monitoring\..*\.amazonaws.com(\/.*)?$/, // Where synthetics posts canary results
+	    /^cw-syn-results(.*)\.amazonaws\.com(.*)?$/, // where synthetics posts canary screenshots
+            /^s3\.amazonaws\.com\/$/, // 
         ];
 
         function handleCanaryRequest(request, urlOrOptions, onStepResult) {

--- a/third-party-synthetic/aws-cloudwatch/web-page-canary_GUI-workflow-builder.js
+++ b/third-party-synthetic/aws-cloudwatch/web-page-canary_GUI-workflow-builder.js
@@ -13,18 +13,15 @@ const flowBuilderBlueprint = async function () {
     });
 
     // Execute customer steps
-    await synthetics.executeStep('customerActions', async function () {
-        await Promise.all([
-          page.waitForNavigation({ timeout: 30000 }),
-          await page.click("nav [href='/trial/']")
-        ]);
-        try {
-            await synthetics.takeScreenshot("redirection", 'result');
-        } catch(ex) {
-            synthetics.addExecutionError('Unable to capture screenshot.', ex);
+    await synthetics.executeStep('click free trial', async function (timeoutInMillis = 30000) {
+        const freeTrial = 'Free trial';
+        const links = await page.$x("//a[contains(., '" + freeTrial + "')]");
+
+        if (links.length == 0) {
+           log.info("'" + freeTrial + "' link not found");
         }
-
-
+        const link = links[0];
+        await page.evaluate(el => el.click(), link);
     });
 };
 

--- a/third-party-synthetic/aws-cloudwatch/web-page-canary_GUI-workflow-builder.js
+++ b/third-party-synthetic/aws-cloudwatch/web-page-canary_GUI-workflow-builder.js
@@ -18,10 +18,13 @@ const flowBuilderBlueprint = async function () {
         const links = await page.$x("//a[contains(., '" + freeTrial + "')]");
 
         if (links.length == 0) {
-           log.info("'" + freeTrial + "' link not found");
+           log.info(`'${freeTrial}' link not found`);
         }
         const link = links[0];
-        await page.evaluate(el => el.click(), link);
+        await Promise.all([
+           page.waitForNavigation({ timeout: 30000 }),
+           page.evaluate(el => el.click(), link)
+        ]);
     });
 };
 


### PR DESCRIPTION
- Fix problem of https://github.com/Dynatrace/dynatrace-api/issues/57 concerning failing canary
- Adapt the ignoredApiUrlPatterns , the requests that should not count as steps for the third-party monitors 
- Fix the web-page-canary_GUI-workflow-builder.js so that it successfully clicks on the "free trial" link

@myieye 