### PR TITLE
Add Metric Expression Examples

### DIFF
--- a/metric-example/README.md
+++ b/metric-example/README.md
@@ -1,0 +1,22 @@
+# Metrics Examples
+Dynatrace supports complex query functionality for metrics data through its _metric selector_ language.
+
+Once you learn the ropes, you can apply that to multiple areas of the product, such as:
+* Metric REST API,
+* Data Explorer,
+* Custom Events for Alerting,
+* SLOs.
+
+## Getting Started
+If you are just getting started with metric selectors and you learn best by example, then
+[Query by Example](query-by-example.md) is a good place for you to start. If you already
+feel comfortable with simple metric selectors and are looking for examples of more advanced
+features of metric selectors, then you may want to check out
+[Metric Expressions by Example](metric-expressions-by-example.md) as well.
+
+## Reference
+Even example-oriented people need to look up something in the reference once in a while.
+
+For that, please refer to the metric selector documentation on
+[dynatrace.com](https://www.dynatrace.com/support/help/dynatrace-api/environment-api/metric-v2/metric-selector/).
+

--- a/metric-example/metric-expressions-by-example.md
+++ b/metric-example/metric-expressions-by-example.md
@@ -1,0 +1,1 @@
+# Metric Expressions by Example

--- a/metric-example/metric-expressions-by-example.md
+++ b/metric-example/metric-expressions-by-example.md
@@ -1,1 +1,246 @@
 # Metric Expressions by Example
+This is an example-oriented document that will teach you advanced 
+techniques with metric selectors that will enable you to:
+* convert °F to Kelvin,
+* calculate an error rate metric from a service call count metric and an error count metric,
+* show the available memory of the hosts that run the most memory-intensive process group instances.
+
+## Prerequisites
+This document assumes basic familiarity with metric selectors. If you don't yet feel comfortable with simple metric selectors, consider reading
+through [Query by Example](query-by-example.md) first.
+
+You can try the examples listed here through the Web UI via _Data Explorer_,
+or you can send selectors to the `/v2/metrics/query` API for evaluation.
+
+## Scenario 1: Convert Fahrenheit to Kelvin
+> **Task** The LHCs magnets cables are kept in a superconducting state by ensuring that
+> their temperature remains under 1.9K. In an effort to improve LHCs uptime,
+> we recently installed temperature sensors that report directly to Dynatrace.
+> Unfortunately, we bought the wrong model and all the measurements are in
+> degrees Fahrenheit. How can we still check for magnets outside the nominal
+> temperature range?
+
+_Note: This scenario uses a notation for the series operator that is only available with Dynatrace versions 228 and later._
+
+Let's convert to Kelvin first and then filter for magnets that are above the
+nominal temperature range:
+```
+(
+  (
+    (temperature) + (459.67)
+  )
+  /
+  (
+    (5) / (9)
+  )
+)
+: filter(
+    series(max, gt(1.9))
+  )
+```
+
+We can see that:
+* `+`, `/` are arithmetic operators in infix notation, with `*` and `-` also available,
+* operands of arithmetic are written in parentheses,
+* `/` and `*` bind more closely than `-` and `+`, but just like in math, we can define a different order of operations by enclosing sub-expressions in parentheses,
+* operators like `:filter` can be applied to a bracketed sub-expression with a calculation in it.
+
+Keep in mind that many metric keys have dashes in them. Those dashes are interpreted literally (as part of the metric key)
+and only become a calculation once the operands are enclosed in parentheses. For example, `request-duration` is a single
+metric key, while `(request)-(duration)` subtracts `duration` from `request`.
+
+## Scenario 2: Percentage of Client Errors
+> **Task** We recently made a breaking change to our API and want to see which percentage
+> of calls to the REST service trigger 4xx errors before and after the introduction of the
+> breaking change.
+
+`builtin:service.errors.fourxx.count` gives us just the amount of service calls with a 4xx exit
+status, while `builtin:service.errors.total.count` additionally includes 5xx errors. If our
+REST service has the entity ID `SERVICE-1234567890`, then we can get the percentage of errors
+in the 4xx range with:
+```
+(
+  (100)
+  *
+  (builtin:service.errors.fourxx.count)
+  /
+  (builtin:service.errors.total.count)
+):filter(eq("dt.entity.service","SERVICE-1234567890"))
+```
+
+How does such a calculation with two separate metrics work? Dynatrace will first find all the series
+with equal dimensions. For each match, we combine the associated data at the same time slot by applying
+the numbers to the arithmetic operator in use. With the result, we assemble a new output series for each
+match.
+
+In the case of our example, we use this functionality to divide error counts that were measured in the
+same time slot.
+
+## Scenario 3: Revenue in Percent over the Query Timeframe
+> **Task** Which percentage of our revenue was made in any given month of the last year?
+
+We store revenue data in a metric called `revenue` that is split by a single dimension
+`region`. Instead of revenue in absolute terms, we want to see for each timeslot what
+percentage of the revenue over the whole query timeframe fall into that timeslot. In other
+words, we want to divide by the combined revenue over the whole query timeframe and multiply
+by 100.
+
+For the multiplication by `100`, we can just use a numeric literal, but for the combined
+revenue we would need a calculated value instead of a fixed one.
+
+To achieve that with metric expressions, we need to reduce the revenue result to a
+single value. This is done by first merging all dimensions into one using `splitBy()`,
+yielding a single dimension-less series. Next, we want to apply `fold` to sum up all of
+the individual data points of this one series, so that we end up with a single number
+for the full revenue.
+
+Putting it all together, we set our resolution to months, set `from` to `now-1y to now`
+and finally our metric selector:
+```
+(100) * (revenue) / (revenue:splitBy():fold)
+```
+
+What would happen if we omitted the `fold`? In that case the percentage in any given timeslot
+will be relative to the full revenue over all regions just in that timeslot, instead of
+being relative to the revenue of the whole timeframe:
+```
+(100) * (revenue) / (revenue:splitBy())
+```
+
+If we omit the `splitBy()`, but keep the `fold`, then the percentages will
+only apply to the current series and each series will sum up to 100 percent:
+```
+(100) * (revenue) / (revenue:fold)
+```
+
+In general, any dimension-less series result or dimension-less point result can be used in
+the same way as a numeric literal. When doing arithmetic, think about which of your operands
+should be series and which should be points (`:fold`). Also think about whether you want
+to pair equal tuples for the calculation, or if you instead want all tuples of one side
+to be paired with a single, empty tuple on the other side (`:splitBy()`). Each combination
+has its own use cases.
+
+## Scenario 4: Response Time Categories
+> **Task** Given a maximum acceptable response time of t = 1.5s in the 99th percentile, we want to
+> classify response times of our services as "satisfactory" (&le; t), "tolerable" (&le; 4t)
+> or "frustrating" (&gt; 4t). We want to see how the service count in each category changes
+> over time.
+
+_Note: This scenario uses the partition operator, which is available in Dynatrace versions 227 and later._
+
+First, we obtain a response time in the 99th percentile for each timeslot and every service,
+and we scale from microseconds to full seconds:
+```
+(builtin:service.response.time:percentile(99)) / (1000) / (1000)
+```
+
+Next up, we want to categorize each data point into one of the three categories. This is done
+by splitting up each series into three new ones, and then assigning each data point to at
+most one of the three new series, depending on their value. When a data point has been assigned
+to one category, the same timeslot will be `null` for the other categories. Let's use the
+`partition` operator to achieve just that:
+```
+: partition(
+    apdexCategory,
+    value("satisfactory", range(0, 1.5)),
+    value("tolerable",    range(1.5, 6)),
+    value("frustrating",  otherwise) 
+  )
+```
+
+Now, the response time series for each series belongs to a new series with "dt.entity.service"
+and "apdexCategory" as their dimensions. Now we want to merge all data with the same category. By specifying
+`:count` after the merge operation, instead of the values, we query just the data point count that
+made it into the merge of each timeslot:
+```
+: splitBy("apdexCategory")
+: count
+```
+
+That's almost what we want, but if no data point was available for a timeslot of a
+category, the value will be a data gap, which is represented with `null`. `0` would be more
+correct for our use case, so let's replace nulls with zero:
+```
+: default(0)
+```
+
+Putting it all together we get:
+```
+((builtin:service.response.time:percentile(99)) / (1000) / (1000))
+: partition(
+    apdexCategory,
+    value("satisfactory", range(0, 1.5)),
+    value("tolerable",    range(1.5, 6)),
+    value("frustrating",  otherwise) 
+  )
+: splitBy("apdexCategory")
+: count
+: default(0)
+```
+
+With the tools from this scenario at our disposal we can:
+* split up data points of series into categories,
+* count merged data points,
+* assign a default value for gaps in the data.
+
+## Scenario 5: Available Memory of Hosts with Top 10 PGIs
+> **Task** We recently increased the maximum heap space for all our Java processes to achieve
+> better utilization of available RAM. We want to verify that there's enough free memory on the hosts where
+> the Top 10 most memory consuming processes run.
+
+Sometimes we want to use one metric for topping and another metric for the actual data.
+`:sort` has no built-in functionality to sort by the values of a metric other than the one
+being sorted, but that is not going to stop us because we have metric expressions at our disposal.
+
+We want to get the top PGIs of `builtin:tech.generic.mem.usage`, transform the dimensions from
+PGIs to only hosts, then replace the values for the top hosts with data from
+`builtin:tech.generic.mem.usage`.
+
+We start with the top hosts part: Get PGI memory usage with `builtin:tech.generic.mem.usage`
+and reduce to the Top 10 by appending `:sort(value(max,descending)):limit(10)`. To view data
+on host level instead of PGI we add host dimensions with `:parents` and then group by them with
+`splitBy("dt.entity.host")`, which also removes the PGIs from the dimension tuples.
+
+Now we have host-based dimension tuples for the top PGIs and want to fill in the values of
+another metric `builtin:host.mem.avail.bytes`. A general pattern to apply topping with `metricA`
+but show the values from `metricB` for the topped dimensions is:
+```
+(<metricA>:sort(...):limit(...))*(0)+(<metricB>)
+```
+
+Let's put it all together:
+```
+(
+  builtin:tech.generic.mem.usage
+  : sort(value(max,descending))
+  : limit(10)
+  : parents
+  : splitBy("dt.entity.host")
+)
+*
+(0)
++
+(builtin:host.mem.avail.bytes)
+```
+
+It worked, we successfully used the PGIs from `builtin:tech.generic.mem.usage` for sorting,
+but the associated hosts and values from `builtin:host.mem.avail.bytes`!
+
+What would have happened if we forgot `:parents:splitBy("dt.entity.host")`, though? Then we
+would have attempted to add PGI data together with Host data, giving us an empty response
+with a warning like the following:
+```
+"Metric expression contains non-matching dimension-keys. Please consider applying `:splitBy()` to all involved operands."
+```
+
+If you encounter such a warning, check the `dimensionDefinitions` of the operands on the schema
+endpoint, and consider adding `splitBy` as needed.
+
+## Further Reading
+Please refer to the documentation on metric expressions on [dyntrace.com](https://www.dynatrace.com/support/help/dynatrace-api/environment-api/metric-v2/metric-expressions/)
+for additional technical details such as:
+* precedence of operators,
+* semantics for combinations of point/series results and literals,
+* null handling,
+* time alignment,
+* many others.

--- a/metric-example/query-by-example.md
+++ b/metric-example/query-by-example.md
@@ -3,7 +3,7 @@ The REST API for metrics gives you access to timeseries data, such as CPU utiliz
 
 A plain metric key is also the simplest form of a metric selector, which is used to specify one or more metrics to the Metric REST API for query, with the option to have the API perform additional transformations on the metric data, such as taking the average, sorting the result, or keeping only data points for satisfied users.
 
-# Prerequisites
+## Prerequisites
 
 Before jumping into the usage scenarios, make sure that you have the following information at hand:
 
@@ -17,7 +17,7 @@ Some of the examples use `curl` to make the actual requests. If you are comforta
 
 Alternatively, use a REST client like [Insomnia](https://insomnia.rest/) or [Postman](https://www.postman.com/), both of which support importing curl commands.
 
-# Scenario 1: Explore Metrics, Dimensions, Aggregation Techniques
+## Scenario 1: Explore Metrics, Dimensions, Aggregation Techniques
 
 > **Task**
 > We want to get a list of available metrics.
@@ -63,7 +63,7 @@ GET {base}/metrics?fields=+dduBillable,+created,+lastWritten,+entityType,+aggreg
 
 The display names and descriptions give us an idea about the contained data. Another critical piece of information is the list of available aggregation techniques. For instance, it is valid to request the average CPU utilization, but the API will reject any request for the median, since it does not make sense for that specific metric.
 
-# Scenario 2: Select One Metric With Full Metadata
+## Scenario 2: Select One Metric With Full Metadata
 
 > **Task**
 > We found an interesting metric and we would like to get more information about what data it provides and which queries we can actually do.
@@ -77,7 +77,7 @@ Accept: text/csv
 
 Note that a full descriptor with all optional fields included is returned when requesting a single metric as a path parameter. Any field name returned here can also be used for the `fields` parameter on `/metrics`.
 
-# Scenario 3: Select Multiple Metrics with Tuples
+## Scenario 3: Select Multiple Metrics with Tuples
 
 >**Task**
 >We want metadata of two related metrics to compare them.
@@ -100,7 +100,7 @@ GET {base}/metrics?metricSelector=builtin:host.cpu.(system,user)
 Accept: text/csv
 ```
 
-# Scenario 4: List Metric Sub-Trees with Wildcards
+## Scenario 4: List Metric Sub-Trees with Wildcards
 
 >**Task**
 >We would like to search for all metrics for a certain topic.
@@ -113,7 +113,7 @@ builtin:host.cpu.*
 
 Note that wildcard selectors are allowed for descriptor queries, but not for bulk metric data queries. Such bulk queries have an upper bound of twelve metrics at a time, and allowing wildcards in a query would make adding new metric keys a breaking change.
 
-# Scenario 5: Full-text Metric Search
+## Scenario 5: Full-text Metric Search
 
 >**Task**
 >We would like to search for all metrics that mention a specific concept in their ID, display name, or description.
@@ -128,7 +128,7 @@ GET {base}/metrics?text=cpu
 
 Turns out there are a whole lot of other metrics related to CPU! Most of them include `cpu` in the metric key, but e.g. `builtin:cloud.kubernetes.cluster.cores` does not. Why does it show up in the result, then? It does because `text` also uses the display name and the description for this search. This is also what the Data Explorer uses to present available metrics when you start typing into the metric field.
 
-# Scenario 6: Querying Time Series Data
+## Scenario 6: Querying Time Series Data
 
 >**Task**
 >We would like to query CPU usage on some hosts during the last 2 weeks.
@@ -156,7 +156,7 @@ builtin:host.cpu.usage,HOST-F1266E1D0AAC2C3C,2019-03-26 15:00:00,10.327820480510
 builtin:host.cpu.usage,HOST-F1266E1D0AAC2C3C,2019-03-26 18:00:00,9.816637022694524
 ```
 
-# Scenario 7: Aggregation with Basic Transformer Chains
+## Scenario 7: Aggregation with Basic Transformer Chains
 
 >**Task**
 >We want to look at the peak CPU usage
@@ -205,7 +205,7 @@ value,"[dt.entity.application:ENTITY, Users:STRING, User type:STRING]",161184828
 ```
 Observing the transformed descriptor is especially useful with more complex transformer chains.
 
-# Scenario 8: Find CPU hogs
+## Scenario 8: Find CPU hogs
 
 >**Task**
 >We just queried CPU data and found a host with abnormally high CPU utilization, but it might not be the only one. How do we query for the 10 hosts with the highest average CPU utilization right now?
@@ -244,7 +244,7 @@ metricId,dt.entity.host.name,dt.entity.host,time,value
 ```
 That's better. You can see that by combining transformations, we can design powerful queries and slice and dice the data as we need it.
 
-# Scenario 9: Average Session Duration of Non-robot First-time Users with Advanced Transformer Chains
+## Scenario 9: Average Session Duration of Non-robot First-time Users with Advanced Transformer Chains
 
 >**Task**
 >We need to provide data on average session duration, but filter out some unwanted types of visits which do not represent a real user.
@@ -284,7 +284,7 @@ Note how the semantics of the transformer chain change with the ordering of the 
 
 We get an error since we just merged the visitor type and then tried to filter on the dimension we just removed.
 
-# Scenario 10: All Service Methods of a Service
+## Scenario 10: All Service Methods of a Service
 
 >**Task**
 >We want to get information for our web service, but by default the data is reported on service method level.
@@ -316,7 +316,7 @@ metricId,dt.entity.service,dt.entity.service_method,time,value
 ```
 If we want to lose the service dimension again after filtering, we can use a `:merge(dt.entity.service)`. The order of transformations is again important. The filter cannot precede the `:parents`, since the dimension does not exist at that point.
 
-# Scenario 11: Apdex for Users of iOS 6.x
+## Scenario 11: Apdex for Users of iOS 6.x
 
 >**Task**
 >We want to filter a secondary dimension (Operating System) by name, rather than by ID.
@@ -340,7 +340,7 @@ metricId,dt.entity.device_application.name,dt.entity.device_application,dt.entit
 ...
 ```
 
-# Scenario 12: Using Space and Time Aggregation with Disk Usages
+## Scenario 12: Using Space and Time Aggregation with Disk Usages
 
 >**Task**
 >For a dashboard, we want a single number for the used disk capacity over all hosts.
@@ -351,7 +351,7 @@ This common transformation pattern looks like a mistake at first, because the ou
 
 Conceptually, you can think of the next aggregation after a `:merge` or `:splitBy` to operate on a list of merged values, supporting any of min, max, avg, sum, median or percentile on that list. Depending on the space aggregation in use, the API will use a suitable data structure to model this conceptual list of merged values (typically a statistical summary or percentile estimator).
 
-# Scenario 13: Combine Series and Point Queries with Folding
+## Scenario 13: Combine Series and Point Queries with Folding
 
 >**Task**
 >For a report, we want to query both per-month CPU usage, but also get an overall average.
@@ -362,7 +362,7 @@ Say we want to access `builtin:host.cpu.usage` over the complete last year from 
 ```
 GET {base}/metrics/query?metricId=builtin:host.cpu.usage:fold,builtin:host.cpu.usage&from=now-y/y&to=now/y&resolution=1M
 ```
-# Scenario 14: Maximum of Average CPU Usage Values Over Time
+## Scenario 14: Maximum of Average CPU Usage Values Over Time
 
 >**Task**
 >For a chart, we want to draw a line that exactly intersects the peak of the graph.
@@ -384,7 +384,7 @@ The result is exactly what we wanted: the maximum average values over time. We c
 
 If you query this selector together with `builtin:host.cpu.usage:avg` you see that the single value is always exactly equal to the maximum entry of the corresponding series.
 
-# Scenario 15: Filtering for Special Characters with Quoting
+## Scenario 15: Filtering for Special Characters with Quoting
 
 >**Task**
 >We have a filter text field, but the resulting metric selector is invalid if we type in special characters.
@@ -415,7 +415,7 @@ builtin:host.disk.avail
  )
 ```
 
-# Scenario 16: Two Metrics with Two Different Entity Selectors
+## Scenario 16: Two Metrics with Two Different Entity Selectors
 
 >**Task**
 >We want to query multiple metrics at once, and each metric should use a different entity selector.
@@ -443,7 +443,7 @@ builtin:host.cpu.usage
 )
 ```
 
-# Scenario 17: Does our Service use Less Memory after the Update
+## Scenario 17: Does our Service use Less Memory after the Update
 
 >**Task**
 >We want to see the CPU utilization graph of yesterday and the day before yesterday, displayed on top of each other in a chart, so that we can look out for differences.
@@ -455,7 +455,7 @@ builtin:tech.generic.cpu.usage:timeshift(-1d),
 ```
 The second time series is shifted one day into the past, showing data from the day before yesterday, but with the same timestamps as the first, un-shifted series. When charting these, they will be displayed on top of each other.
 
-# Scenario 18: Last Stock Price Yesterday
+## Scenario 18: Last Stock Price Yesterday
 
 >**Task**
 >We want the last reported value just before midnight yesterday, but if the last time slot contains a gap in the data, we want to go back and instead see the last non-null data.
@@ -466,11 +466,11 @@ stock_price:last
 ```
 If there is at least one non-null data point, the result will use the latest value or otherwise be empty.
 
-# Other Functionality Related to Metric Selectors
+## Other Functionality Related to Metric Selectors
 
 The parameters `from`, `to` and `resolution` are not part of the metric selector but apply to the whole query. Nonetheless, this section provides a high-level overview that will help you use them effectively.
 
-## Choosing Resolution and Time Frame
+### Choosing Resolution and Time Frame
 
 `from` and `to` accept multiple date formats, including milliseconds since 1970 and human-readable dates in year-month-day order that may include time-of-day, as well as GMT offset. Additionally, a simple format for relative dates is accepted.
 
@@ -489,7 +489,7 @@ Resolution accepts identical units, e.g. `M` or `1M` signifies one month of time
 
 It is important to note that the resolution is intended as a hint to the server about a preferred count or resolution. When the wish for a resolution cannot be fulfilled exactly, e.g. when requesting eleven minutes between data points, the API will try to find the most satisfying available resolution. Further, the query timeframe may not be aligned with how data points are stored internally, causing the API to extend the timeframe outwards. For these reasons, the API sometimes returns more data points than requested.
 
-## Entity Selector
+### Entity Selector
 
 Per default, metrics are requested for the universal scope, encompassing the complete Dynatrace environment that the authenticated user has access to. More often than not, only a subset of this data is required. A restricted query is facilitated by the specification of an entity selector expression, sometimes referred to as an entity scope.
 
@@ -507,6 +507,6 @@ entitySelector=type(HOST),tag(Europe),tag(Linux)
 ```
 You can see that compound scope expressions are built by AND-connecting predicate expressions with the comma character.
 
-# Further Reading
+## Further Reading
 
 **To learn more about entity selectors, see the [Official EntitySelector Documentation](https://www.dynatrace.com/support/help/dynatrace-api/environment-api/entity-v2/entity-selector/).**

--- a/metric-example/query-by-example.md
+++ b/metric-example/query-by-example.md
@@ -1,5 +1,4 @@
-# Introduction
-
+# Query by Example
 The REST API for metrics gives you access to timeseries data, such as CPU utilization of a host or service or the bounce rate of a web application. For instance, free disk space, per host, per disk is uniquely identified with `builtin:host.disk.avail`. This hierarchical identifier is referred to as a metric key.
 
 A plain metric key is also the simplest form of a metric selector, which is used to specify one or more metrics to the Metric REST API for query, with the option to have the API perform additional transformations on the metric data, such as taking the average, sorting the result, or keeping only data points for satisfied users.


### PR DESCRIPTION
Adds an example-oriented document to teach the metric expression feature of metric selectors, which enable users to calculate within metric expressions. Also adds an overview README document in `metric-example` that gives a brief overview of the contents of the other two markdown files with actual example content.

The new content can be considered part two of [Query by Example](https://github.com/Dynatrace/dynatrace-api/blob/master/metric-example/query-by-example.md), which is still included in the new version.

An initial review was done within the metrics team, but please feel free to have another look.

See [my fork](https://github.com/dt-phstadler/dynatrace-api/tree/feature/metric-expression-examples/metric-example) for a preview of the changes.